### PR TITLE
Use the reload() method to trigger the reload in the ListStore

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -8,7 +8,8 @@
         "@babel/plugin-transform-flow-strip-types",
         "@babel/plugin-proposal-nullish-coalescing-operator",
         "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-optional-chaining"
+        "@babel/plugin-proposal-optional-chaining",
+        "@babel/plugin-proposal-export-namespace-from"
     ],
     "assumptions": {
         "setPublicClassFields": true

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "@babel/core": "^7.5.5",
         "@babel/plugin-proposal-class-properties": "^7.16.5",
         "@babel/plugin-proposal-decorators": "^7.4.4",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
         "@babel/plugin-proposal-optional-chaining": "^7.18.9",
         "@babel/plugin-transform-flow-strip-types": "^7.4.4",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/HtmlFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/HtmlFieldTransformer.js
@@ -10,7 +10,7 @@ export default class HtmlFieldTransformer implements FieldTransformer {
             return null;
         }
 
-        const sanitizedHtml = sanitizeHtml(value, {
+        const sanitizedHtml = sanitizeHtml(value.toString(), {
             allowedTags: ['b', 'em', 'i', 's', 'small', 'strong', 'sub', 'sup', 'time', 'u'],
             allowedAttributes: {},
             disallowedTagsMode: 'recursiveEscape',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -391,8 +391,8 @@ export default class ListStore {
         this.structureStrategy = structureStrategy;
 
         if (hadStructureStrategy) {
-            // force a reload with the currently active item to match new structure
-            this.activate(this.active.get());
+            // force a reload to match new structure
+            this.reload();
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -1792,9 +1792,10 @@ test('Should trigger a mobx autorun if activate is called with the same id', () 
     autorunDisposer();
 });
 
-test('Should activate the current item if structure strategy is changed to trigger a reload', () => {
+test('Should call the reload method if structure strategy is changed', () => {
     const page = observable.box();
     const listStore = new ListStore('snippets', 'snippets', 'list_test', {page});
+    const reloadSpy = jest.spyOn(listStore, 'reload');
     listStore.schema = {};
 
     const loadingStrategy = new LoadingStrategy();
@@ -1808,7 +1809,7 @@ test('Should activate the current item if structure strategy is changed to trigg
 
     const otherStructureStrategy = new StructureStrategy();
     listStore.updateStructureStrategy(otherStructureStrategy);
-    expect(otherStructureStrategy.activate).toBeCalledWith(3);
+    expect(reloadSpy).toBeCalled();
 });
 
 test('Should call the activate method of the structure strategy if an item gets activated', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                 {
                     test: /\.js$/,
                     // eslint-disable-next-line max-len
-                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
+                    exclude: /node_modules[/\\](?!(sulu-(.*)-bundle|@ckeditor|ckeditor5|array-move|htmlparser2|lodash-es|@react-leaflet|react-leaflet)[/\\])/,
                     use: {
                         loader: 'babel-loader',
                         options: {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Explain the contents of the PR.

#### Why?

Which problem does the PR fix? (remove this section if you linked an issue above)

#### Example Usage

~~~php
// If you added new features, show examples of how to use them here
// (remove this section if not a new feature)

$foo = new Foo();

// Now we can do
$foo->doSomething();
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
